### PR TITLE
Element.Value  unsafe.Pointer -> interface{}

### DIFF
--- a/buffer_list.go
+++ b/buffer_list.go
@@ -33,10 +33,11 @@ const (
 )
 
 type Element struct {
-	list  *List
-	next  *Element
-	prev  *Element
-	value unsafe.Pointer
+	list      *List
+	next      *Element
+	prev      *Element
+	old_value unsafe.Pointer
+	value     interface{}
 }
 
 type List struct {

--- a/buffer_list.go
+++ b/buffer_list.go
@@ -51,7 +51,7 @@ type List struct {
 	datas     []byte
 	Len       int
 	m         sync.Mutex
-	cast_f    func(unsafe.Pointer) interface{}
+	cast_f    func(interface{}) interface{}
 }
 
 func New(first_value interface{}, buf_cnt int) *List {
@@ -63,7 +63,7 @@ func New(first_value interface{}, buf_cnt int) *List {
 
 func (l *List) getElemData(idx int64) *Element {
 	elm := (*Element)(unsafe.Pointer(&l.elms[int(l.SizeElm)*int(idx)]))
-	elm.value = unsafe.Pointer(&l.datas[int(l.SizeData)*int(idx)])
+	elm.value = reflect.NewAt(l.TypeOfValue_inf(), unsafe.Pointer(&l.datas[int(l.SizeData)*int(idx)])).Interface()
 	return elm
 }
 func (l *List) GetElement() *Element {
@@ -91,7 +91,7 @@ func (e *Element) Prev() *Element {
 	}
 }
 
-func (e *Element) Value() unsafe.Pointer {
+func (e *Element) Value() interface{} {
 	return e.value
 }
 
@@ -210,6 +210,14 @@ func (l *List) InsertNewElem(at *Element) *Element {
 	return e
 }
 
+func (l *List) TypeOfValue_inf() reflect.Type {
+	if reflect.TypeOf(l.Value_inf).Kind() == reflect.Ptr {
+		return reflect.ValueOf(l.Value_inf).Elem().Type()
+	} else {
+		return reflect.TypeOf(l.Value_inf)
+	}
+}
+
 func (l *List) Init(first_value interface{}, value_len int) *List {
 	l.m.Lock()
 	defer l.m.Unlock()
@@ -221,14 +229,14 @@ func (l *List) Init(first_value interface{}, value_len int) *List {
 			buf_len = int64(value_len)
 		}
 		l.Value_inf = first_value
-		l.SizeData = int64(reflect.TypeOf(first_value).Size())
+		l.SizeData = int64(l.TypeOfValue_inf().Size())
 		l.SizeElm = int64(reflect.TypeOf(Element{}).Size())
 		l.elms = make([]byte, buf_len*l.SizeElm,
 			buf_len*l.SizeElm)
 		l.datas = make([]byte, buf_len*l.SizeData,
 			buf_len*l.SizeData)
 		elm := (*Element)(unsafe.Pointer(&l.elms[0]))
-		elm.value = unsafe.Pointer(&l.datas[0])
+		elm.value = reflect.NewAt(l.TypeOfValue_inf(), unsafe.Pointer(&l.datas[0])).Interface()
 		elm.prev = elm
 		elm.next = nil
 		elm.list = l
@@ -262,10 +270,10 @@ func (l *List) Inf() interface{} {
 	return l.Value_inf
 }
 
-func (l *List) Value() unsafe.Pointer {
+func (l *List) Value() interface{} {
 	return l.Used.value
 }
-func (l *List) SetCastFunc(f func(val unsafe.Pointer) interface{}) {
+func (l *List) SetCastFunc(f func(val interface{}) interface{}) {
 	l.cast_f = f
 }
 

--- a/buffer_list_test.go
+++ b/buffer_list_test.go
@@ -12,7 +12,7 @@ type TestData struct {
 
 func createList() *List {
 	list := New(TestData{}, 4096)
-	data := (*TestData)(list.Front().Value())
+	data := list.Front().Value().(*TestData)
 	data.a = 1
 	data.b = 11
 
@@ -33,7 +33,7 @@ func TestBufferListInsertNewElem(t *testing.T) {
 	list := createList()
 
 	e := list.InsertNewElem(list.Front())
-	data := (*TestData)(e.Value())
+	data := e.Value().(*TestData)
 
 	data.a = 2
 	data.b = 22
@@ -42,7 +42,7 @@ func TestBufferListInsertNewElem(t *testing.T) {
 		t.Error("list.Len != 2")
 	}
 
-	data2 := (*TestData)(list.Back().Value())
+	data2 := list.Back().Value().(*TestData)
 
 	if data2.a != 2 {
 		t.Error("data2.a != 2")
@@ -56,7 +56,7 @@ func TestBufferListCreate1000(t *testing.T) {
 	var e *Element
 	for i := 1; i < 1000; i++ {
 		e = list.InsertNewElem(list.Back())
-		data = (*TestData)(e.Value())
+		data = e.Value().(*TestData)
 		data.a = int64(i) * 1
 		data.b = int32(i) * 11
 	}
@@ -65,7 +65,7 @@ func TestBufferListCreate1000(t *testing.T) {
 		t.Error("list.len != 10")
 	}
 
-	data = (*TestData)(list.Back().Prev().Value())
+	data = list.Back().Prev().Value().(*TestData)
 
 	if data.b != 998*11 {
 		t.Error("data.b != 998*11", data.b)
@@ -79,7 +79,7 @@ func TestBufferListConcurrentCreate1000(t *testing.T) {
 
 	c_elm := func(list *List, i int, fin chan bool) {
 		ee := list.InsertNewElem(list.Back())
-		tdata := (*TestData)(ee.Value())
+		tdata := ee.Value().(*TestData)
 		tdata.a = int64(i) * 1
 		tdata.b = int32(i) * 11
 		fin <- true


### PR DESCRIPTION
if Element.Value is unsafe.Pointer and Value is struct with pointer member, 
Value's pointer member is freeed by GC .
if Element.Value is interface{},  runtime track Value.member and not freed by GC
